### PR TITLE
Fixed Restart hyperlink

### DIFF
--- a/main.py
+++ b/main.py
@@ -168,7 +168,7 @@ def tic_tac_toe():
 
     resp += '''
             <br>
-            <a href="/cpu">Restart</a>
+            <a href="/one_on_one">Restart</a>
             <a href="/">Home</a>
             '''
 


### PR DESCRIPTION
Fixed the restart hyperlink in one_on_one not linking to correct directory.